### PR TITLE
fix: prevent keychain password disclosure during CI import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 target/book
+.worktrees/

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,4 +1,4 @@
-use crate::subprocess::{run, SubprocessError};
+use crate::subprocess::{run, run_args, Arg, SubprocessError};
 use rand_core::RngCore;
 use std::path::{Path, PathBuf};
 
@@ -387,6 +387,15 @@ pub fn load_keychain_state(path: &Path) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+/// Generate a keychain name and an independent password for ephemeral CI keychains.
+fn generate_keychain_credentials() -> (String, String) {
+    let name_suffix: u64 = rand_core::OsRng.next_u64();
+    let keychain_name = format!("cargo-sign-{name_suffix}.keychain");
+    // Use a separate random value so the password is not derivable from the name.
+    let keychain_password = format!("{}", rand_core::OsRng.next_u64());
+    (keychain_name, keychain_password)
+}
+
 /// Import a `.p12` certificate into an ephemeral keychain (for CI api-key mode).
 /// Returns the keychain path for later cleanup.
 pub fn import_certificate(
@@ -394,16 +403,19 @@ pub fn import_certificate(
     cert_password: &str,
     verbose: bool,
 ) -> Result<PathBuf, MacosSignError> {
-    let random_suffix: u64 = rand_core::OsRng.next_u64();
-    let keychain_name = format!("cargo-sign-{random_suffix}.keychain");
-    let keychain_password = format!("{random_suffix}");
+    let (keychain_name, keychain_password) = generate_keychain_credentials();
 
     let cert_str = cert_p12_path.to_string_lossy().to_string();
 
     // Create ephemeral keychain
-    let output = run(
+    let output = run_args(
         "security",
-        &["create-keychain", "-p", &keychain_password, &keychain_name],
+        &[
+            "create-keychain".into(),
+            "-p".into(),
+            Arg::sensitive(&keychain_password),
+            keychain_name.as_str().into(),
+        ],
         verbose,
     )?;
     if !output.success {
@@ -414,17 +426,17 @@ pub fn import_certificate(
     }
 
     // Import certificate
-    let output = run(
+    let output = run_args(
         "security",
         &[
-            "import",
-            &cert_str,
-            "-k",
-            &keychain_name,
-            "-P",
-            cert_password,
-            "-T",
-            "/usr/bin/codesign",
+            "import".into(),
+            cert_str.as_str().into(),
+            "-k".into(),
+            keychain_name.as_str().into(),
+            "-P".into(),
+            Arg::sensitive(cert_password),
+            "-T".into(),
+            "/usr/bin/codesign".into(),
         ],
         verbose,
     )?;
@@ -438,16 +450,16 @@ pub fn import_certificate(
     }
 
     // Set key partition list so codesign can access the key
-    let output = run(
+    let output = run_args(
         "security",
         &[
-            "set-key-partition-list",
-            "-S",
-            "apple-tool:,apple:,codesign:",
-            "-s",
-            "-k",
-            &keychain_password,
-            &keychain_name,
+            "set-key-partition-list".into(),
+            "-S".into(),
+            "apple-tool:,apple:,codesign:".into(),
+            "-s".into(),
+            "-k".into(),
+            Arg::sensitive(&keychain_password),
+            keychain_name.as_str().into(),
         ],
         verbose,
     )?;
@@ -564,5 +576,24 @@ mod tests {
         let state_path = dir.path().join(".codesign-keychain");
         let result = load_keychain_state(&state_path);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn keychain_credentials_have_independent_password() {
+        let (name, password) = generate_keychain_credentials();
+
+        assert!(name.starts_with("cargo-sign-"));
+        assert!(name.ends_with(".keychain"));
+
+        let suffix = name
+            .strip_prefix("cargo-sign-")
+            .unwrap()
+            .strip_suffix(".keychain")
+            .unwrap();
+
+        assert_ne!(
+            suffix, password,
+            "keychain password must not equal the name's random suffix"
+        );
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -425,6 +425,20 @@ pub fn import_certificate(
         )));
     }
 
+    // Disable auto-lock (default is 300s which is too short for CI builds)
+    let output = run(
+        "security",
+        &["set-keychain-settings", "-lut", "3600", &keychain_name],
+        verbose,
+    )?;
+    if !output.success {
+        let _ = run("security", &["delete-keychain", &keychain_name], false);
+        return Err(MacosSignError::KeychainFailed(format!(
+            "set-keychain-settings failed: {}",
+            output.stderr
+        )));
+    }
+
     // Import certificate
     let output = run_args(
         "security",

--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::process::Command;
 
 #[derive(Debug)]
@@ -17,14 +18,64 @@ pub enum SubprocessError {
     },
 }
 
-pub fn run(command: &str, args: &[&str], verbose: bool) -> Result<RunOutput, SubprocessError> {
-    if verbose {
-        eprintln!("  $ {} {}", command, args.join(" "));
+/// A command-line argument that may or may not contain sensitive data.
+///
+/// `Display` always redacts `Sensitive` values, so accidental logging or
+/// formatting cannot leak secrets.
+#[derive(Debug, Clone, Copy)]
+pub enum Arg<'a> {
+    Plain(&'a str),
+    Sensitive(&'a str),
+}
+
+impl<'a> Arg<'a> {
+    pub fn sensitive(s: &'a str) -> Self {
+        Arg::Sensitive(s)
     }
 
+    pub fn as_str(&self) -> &'a str {
+        match self {
+            Arg::Plain(s) | Arg::Sensitive(s) => s,
+        }
+    }
+}
+
+impl<'a> From<&'a str> for Arg<'a> {
+    fn from(s: &'a str) -> Self {
+        Arg::Plain(s)
+    }
+}
+
+impl fmt::Display for Arg<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Arg::Plain(s) => f.write_str(s),
+            Arg::Sensitive(_) => f.write_str("****"),
+        }
+    }
+}
+
+/// Run a subprocess, passing all arguments as plain (non-sensitive) strings.
+pub fn run(command: &str, args: &[&str], verbose: bool) -> Result<RunOutput, SubprocessError> {
+    let typed: Vec<Arg<'_>> = args.iter().map(|&s| Arg::Plain(s)).collect();
+    run_args(command, &typed, verbose)
+}
+
+/// Run a subprocess with typed arguments that distinguish sensitive values.
+pub fn run_args(
+    command: &str,
+    args: &[Arg<'_>],
+    verbose: bool,
+) -> Result<RunOutput, SubprocessError> {
+    if verbose {
+        let display: Vec<_> = args.iter().map(ToString::to_string).collect();
+        eprintln!("  $ {} {}", command, display.join(" "));
+    }
+
+    let raw: Vec<&str> = args.iter().map(Arg::as_str).collect();
     let output =
         Command::new(command)
-            .args(args)
+            .args(&raw)
             .output()
             .map_err(|e| SubprocessError::SpawnFailed {
                 command: command.to_string(),
@@ -47,4 +98,46 @@ pub fn run(command: &str, args: &[&str], verbose: bool) -> Result<RunOutput, Sub
         success: output.status.success(),
         code: output.status.code(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sensitive_arg_display_is_redacted() {
+        let arg = Arg::sensitive("super-secret-password");
+        assert_eq!(arg.to_string(), "****");
+    }
+
+    #[test]
+    fn plain_arg_display_shows_value() {
+        let arg = Arg::Plain("visible-value");
+        assert_eq!(arg.to_string(), "visible-value");
+    }
+
+    #[test]
+    fn sensitive_arg_as_str_exposes_real_value() {
+        let arg = Arg::sensitive("real-password");
+        assert_eq!(arg.as_str(), "real-password");
+    }
+
+    #[test]
+    fn from_str_creates_plain_arg() {
+        let arg: Arg<'_> = "hello".into();
+        assert_eq!(arg.to_string(), "hello");
+        assert_eq!(arg.as_str(), "hello");
+    }
+
+    #[test]
+    fn mixed_args_display_redacts_only_sensitive() {
+        let args: Vec<Arg<'_>> = vec![
+            "create-keychain".into(),
+            "-p".into(),
+            Arg::sensitive("my-secret"),
+            "keychain-name".into(),
+        ];
+        let display: Vec<String> = args.iter().map(ToString::to_string).collect();
+        assert_eq!(display, &["create-keychain", "-p", "****", "keychain-name"]);
+    }
 }


### PR DESCRIPTION
## Summary

- **Decouple keychain password from name**: The ephemeral keychain password was `format!("{random_suffix}")` — identical to the suffix in the filename `cargo-sign-{random_suffix}.keychain`. Anyone who could see the filename could derive the password. Now uses a second independent `OsRng.next_u64()` call.
- **Type-safe argument redaction**: Introduces an `Arg<'a>` enum (`Plain` / `Sensitive`) whose `Display` impl always emits `****` for sensitive values. The `run_args()` function uses this for verbose logging, making it structurally impossible to accidentally leak passwords via `format!`, `eprintln!`, or any other display path.
- **Targeted usage**: Only `import_certificate()` uses `run_args` with `Arg::sensitive()` for the keychain password and .p12 certificate password. All other call sites continue using `run()` unchanged.
- **Disable keychain auto-lock**: Default timeout is 300s, which can expire during long CI builds and cause `codesign` to fail with a cryptic access error. Sets `-lut 3600` right after creation.

Closes #25

## Test plan

- [x] `keychain_credentials_have_independent_password` — verifies the password is not equal to the name's random suffix
- [x] `sensitive_arg_display_is_redacted` — verifies `Arg::Sensitive("x").to_string() == "****"`
- [x] `plain_arg_display_shows_value` — verifies plain args display normally
- [x] `mixed_args_display_redacts_only_sensitive` — verifies mixed arg slices redact correctly
- [x] All 70 existing tests pass
- [x] Clippy clean, rustfmt clean