### PR TITLE
fix: staple .app before DMG for Homebrew cask gatekeeper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-codesign"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "cargo-codesign"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Cross-platform binary signing CLI for Rust projects"

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,7 +326,7 @@ fn macos_app_mode(
         .to_string_lossy()
         .to_string();
 
-    eprintln!("[1/5] Codesigning .app bundle...");
+    eprintln!("[1/7] Codesigning .app bundle...");
     let opts = macos::CodesignOpts {
         identity,
         entitlements,
@@ -338,8 +338,32 @@ fn macos_app_mode(
     });
     eprintln!("  ✓ App signed");
 
+    if !skip_notarize {
+        eprintln!("[2/7] Zipping .app for notarization...");
+        let zip_path = macos::zip_app(app_path, verbose).unwrap_or_else(|e| {
+            eprintln!("✗ Zip creation failed: {e}");
+            std::process::exit(1);
+        });
+        eprintln!("  ✓ Zip created: {}", zip_path.display());
+
+        eprintln!("[3/7] Notarizing .app...");
+        notarize_artifact(&zip_path, macos_config, verbose);
+        eprintln!("  ✓ Notarized");
+
+        let _ = std::fs::remove_file(&zip_path);
+
+        if !skip_staple {
+            eprintln!("[4/7] Stapling .app...");
+            macos::staple(app_path, verbose).unwrap_or_else(|e| {
+                eprintln!("✗ App stapling failed: {e}");
+                std::process::exit(1);
+            });
+            eprintln!("  ✓ App stapled");
+        }
+    }
+
     let dmg_path = app_path.with_extension("dmg");
-    eprintln!("[2/5] Creating DMG...");
+    eprintln!("[5/7] Creating DMG...");
     macos::create_dmg(
         app_path,
         &dmg_path,
@@ -353,7 +377,7 @@ fn macos_app_mode(
     });
     eprintln!("  ✓ DMG created: {}", dmg_path.display());
 
-    eprintln!("[3/5] Codesigning DMG...");
+    eprintln!("[6/7] Codesigning DMG...");
     let dmg_opts = macos::CodesignOpts {
         identity,
         entitlements: None,
@@ -365,19 +389,13 @@ fn macos_app_mode(
     });
     eprintln!("  ✓ DMG signed");
 
-    if !skip_notarize {
-        eprintln!("[4/5] Notarizing DMG...");
-        notarize_artifact(&dmg_path, macos_config, verbose);
-        eprintln!("  ✓ Notarized");
-    }
-
     if !skip_notarize && !skip_staple {
-        eprintln!("[5/5] Stapling...");
+        eprintln!("[7/7] Stapling DMG...");
         macos::staple(&dmg_path, verbose).unwrap_or_else(|e| {
-            eprintln!("✗ Stapling failed: {e}");
+            eprintln!("✗ DMG stapling failed: {e}");
             std::process::exit(1);
         });
-        eprintln!("  ✓ Stapled");
+        eprintln!("  ✓ DMG stapled");
     }
 
     eprintln!("✓ Done: {}", dmg_path.display());

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -10,6 +10,8 @@ pub enum MacosSignError {
     CodesignFailed { path: PathBuf, detail: String },
     #[error("DMG creation failed: {0}")]
     DmgCreationFailed(String),
+    #[error("zip creation failed: {0}")]
+    ZipFailed(String),
     #[error("notarization failed: {0}")]
     NotarizationFailed(String),
     #[error("stapling failed: {0}")]
@@ -339,6 +341,23 @@ pub fn staple(artifact: &Path, verbose: bool) -> Result<(), MacosSignError> {
         return Err(MacosSignError::StaplingFailed(output.stderr));
     }
     Ok(())
+}
+
+/// Zip a `.app` bundle for notarization submission via `ditto`.
+pub fn zip_app(app_path: &Path, verbose: bool) -> Result<PathBuf, MacosSignError> {
+    let zip_path = app_path.with_extension("zip");
+    let app_str = app_path.to_string_lossy().to_string();
+    let zip_str = zip_path.to_string_lossy().to_string();
+
+    let output = run(
+        "ditto",
+        &["-c", "-k", "--keepParent", &app_str, &zip_str],
+        verbose,
+    )?;
+    if !output.success {
+        return Err(MacosSignError::ZipFailed(output.stderr));
+    }
+    Ok(zip_path)
 }
 
 /// Decode a base64-encoded `.p12` certificate to a temp file.


### PR DESCRIPTION
## Summary

- Notarize the `.app` (via zip submission) and staple it **before** creating the DMG
- Ensures the `.app` carries its own notarization ticket when extracted from the DMG
- Fixes Gatekeeper rejections on MDM-restricted or offline machines when installed via `brew install --cask`

## Context

When only the DMG is stapled, macOS can verify notarization online. But Homebrew cask extracts the `.app` and places it directly in `/Applications` — losing the DMG's ticket context. On machines that can't reach Apple's servers (corporate MDM, firewalls), Gatekeeper shows "Apple could not verify" and blocks the app.

Confirmed: VS Code, Firefox, iTerm all staple their `.app` bundles directly.

## New flow (was 5 steps, now 7)

1. Sign `.app`
2. Zip `.app` for notarization submission
3. Notarize via `notarytool submit`
4. Staple `.app` (fetches ticket from Apple servers)
5. Create DMG (now contains stapled `.app`)
6. Sign DMG
7. Staple DMG

## Test plan

- [ ] Run `cargo codesign macos --app Foo.app` on a signed app
- [ ] Verify `stapler validate Foo.app` passes after step 4
- [ ] Verify extracted `.app` from DMG also passes `stapler validate`
- [ ] Install via `brew install --cask` and confirm no Gatekeeper warning