### PR TITLE
feat: add --as zip|dmg output format flag to --app mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-05-08
+
+### Features
+
+- Add `--as zip|dmg` flag to `--app` mode for choosing output format ([#40](https://github.com/sassman/cargo-codesign-rs/pull/40))
+  - `--as zip`: produces a zip containing the stapled `.app` (ideal for Homebrew cask)
+  - `--as dmg` (default): produces a fully notarized+stapled DMG
+
+### Bug Fixes
+
+- DMG flow now notarizes both `.app` and DMG separately, ensuring both carry stapled tickets
+
 ## [0.3.0] - 2026-05-08
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-codesign"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "cargo-codesign"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Cross-platform binary signing CLI for Rust projects"

--- a/book/src/macos/app-mode.md
+++ b/book/src/macos/app-mode.md
@@ -1,71 +1,115 @@
 # Signing a GUI App (--app mode)
 
-This is the most common mode for macOS GUI applications. It handles the full pipeline from `.app` bundle to signed, notarized DMG.
+This is the most common mode for macOS GUI applications. It handles the full pipeline from `.app` bundle to a signed, notarized, distributable artifact.
+
+## Output formats
+
+Use `--as` to choose how the final artifact is packaged:
+
+| Flag | Output | Best for |
+|------|--------|----------|
+| `--as dmg` (default) | Signed + notarized DMG | Direct website downloads (drag-to-install) |
+| `--as zip` | Zip containing stapled `.app` | Homebrew cask, Sparkle updaters |
+
+In both cases the `.app` itself is signed, notarized, and stapled — the difference is only the outer container.
 
 ## Quick start
 
-```bash
-cargo codesign macos --app "target/release/bundle/MyApp.app"
-```
+### Zip output (for Homebrew cask)
 
-This runs:
+```bash
+cargo codesign macos --app "MyApp.app" --as zip
+```
 
 ```
 [1/5] Codesigning .app bundle...
   ✓ App signed
-[2/5] Creating DMG...
-  ✓ DMG created: target/release/bundle/MyApp.dmg
-[3/5] Codesigning DMG...
-  ✓ DMG signed
-[4/5] Notarizing DMG...
+[2/5] Zipping .app for notarization...
+  ✓ Zip created: MyApp.zip
+[3/5] Notarizing .app...
   ✓ Notarized
-[5/5] Stapling...
-  ✓ Stapled
-✓ Done: target/release/bundle/MyApp.dmg
+[4/5] Stapling .app...
+  ✓ App stapled
+[5/5] Creating distributable zip...
+  ✓ Zip created
+✓ Done: MyApp.zip
 ```
+
+### DMG output (default)
+
+```bash
+cargo codesign macos --app "MyApp.app"
+# or explicitly: cargo codesign macos --app "MyApp.app" --as dmg
+```
+
+```
+[1/8] Codesigning .app bundle...
+  ✓ App signed
+[2/8] Zipping .app for notarization...
+  ✓ Zip created: MyApp.zip
+[3/8] Notarizing .app...
+  ✓ Notarized
+[4/8] Stapling .app...
+  ✓ App stapled
+[5/8] Creating DMG...
+  ✓ DMG created: MyApp.dmg
+[6/8] Codesigning DMG...
+  ✓ DMG signed
+[7/8] Notarizing DMG...
+  ✓ Notarized
+[8/8] Stapling DMG...
+  ✓ DMG stapled
+✓ Done: MyApp.dmg
+```
+
+Note: the DMG flow performs **two** notarization submissions (one for the `.app`, one for the DMG) so both carry stapled tickets.
 
 ## What happens at each step
 
-### Step 1: Sign inner binaries and the .app bundle
+### Sign .app bundle
 
 cargo-codesign walks the `.app` bundle and signs:
 1. Every binary in `Contents/MacOS/`
 2. Every dylib and framework in `Contents/Frameworks/`
 3. The `.app` bundle itself (with entitlements if configured)
 
-Each is signed with `codesign --force --timestamp --options runtime`, which enables the hardened runtime required for notarization.
+Each is signed with `codesign --force --timestamp --options runtime`, enabling the hardened runtime required for notarization.
 
-### Step 2: Create DMG
+### Notarize .app
 
-Creates a DMG from the `.app` using `hdiutil`. The DMG is placed next to the `.app`:
+The `.app` is zipped and submitted to Apple's notarization service. This typically takes 1-5 minutes. On failure, cargo-codesign prints the notarization log with specific issues.
 
-```
-target/release/bundle/MyApp.app  →  target/release/bundle/MyApp.dmg
-```
+### Staple .app
 
-When a `[macos.dmg]` section is present in `sign.toml`, the DMG gets a styled installer window with your background image and positioned icons. See [DMG Styling](./dmg-styling.md) for setup instructions.
+Attaches the notarization ticket directly to the `.app` bundle. This ensures Gatekeeper passes even on machines that cannot reach Apple's servers (corporate firewalls, MDM-restricted Macs).
 
-### Step 3: Sign the DMG
+### Create DMG (dmg mode only)
 
-The DMG itself must also be codesigned — Apple's notarization service requires it.
+Creates a DMG from the stapled `.app` using `hdiutil`. When a `[macos.dmg]` section is present in `sign.toml`, the DMG gets a styled installer window. See [DMG Styling](./dmg-styling.md).
 
-### Step 4: Notarize
+### Sign + notarize + staple DMG (dmg mode only)
 
-Submits the DMG to Apple's notarization service and waits for the result. This typically takes 1-5 minutes.
+The DMG is codesigned, submitted for a second notarization, and stapled so direct-download users get offline Gatekeeper verification on the DMG itself.
 
-On failure, cargo-codesign prints the notarization log with specific issues (e.g., unsigned binary inside the bundle, forbidden entitlement).
+## When to use which format
 
-### Step 5: Staple
+**Use `--as zip` when:**
+- Distributing via Homebrew cask (cask extracts the `.app` from the zip)
+- Using Sparkle or similar updater frameworks that expect a zip
+- You want a single notarization (faster CI)
 
-Attaches the notarization ticket to the DMG so it works offline — users don't need to be online for Gatekeeper to verify.
+**Use `--as dmg` (default) when:**
+- Users download from your website and expect drag-to-install
+- You want a styled installer window with background image
+
+You can produce both in CI by running the command twice with different `--as` flags.
 
 ## Skipping steps
 
 For development builds where you don't need notarization:
 
 ```bash
-# Sign only, skip notarization and stapling
-cargo codesign macos --app "MyApp.app" --skip-notarize
+cargo codesign macos --app "MyApp.app" --as zip --skip-notarize
 ```
 
 ## Overriding config from the command line
@@ -90,16 +134,7 @@ cargo build --release --target aarch64-apple-darwin -p my-app
 # 2. Bundle (your script or cargo-bundle)
 ./scripts/bundle-macos.sh
 
-# 3. Sign (cargo-codesign handles the rest)
-cargo codesign macos --app "target/release/bundle/MyApp.app"
-```
-
-Or if you use a Makefile:
-
-```makefile
-dmg:
-	cargo build --release --target aarch64-apple-darwin -p my-app
-	./scripts/bundle-macos.sh
-	set -a && source .env && set +a && \
-		cargo codesign macos --app "target/release/bundle/MyApp.app"
+# 3. Sign — zip for Homebrew, dmg for website
+cargo codesign macos --app "target/release/bundle/MyApp.app" --as zip
+cargo codesign macos --app "target/release/bundle/MyApp.app" --as dmg
 ```

--- a/book/src/macos/overview.md
+++ b/book/src/macos/overview.md
@@ -13,15 +13,25 @@ Skip any of these and users see the dreaded "Apple could not verify" dialog — 
 `cargo codesign macos` runs the full pipeline:
 
 ```
-.app bundle ──► sign inner binaries ──► sign .app ──► create DMG
-                                                          │
-                                            sign DMG ◄────┘
-                                                │
-                                          notarize DMG
-                                                │
-                                           staple DMG
-                                                │
-                                         ✓ Ready to ship
+.app bundle ──► sign inner binaries ──► sign .app
+                                            │
+                          ┌─────────────────┼─────────────────┐
+                          │                                   │
+                     --as zip                            --as dmg
+                          │                                   │
+                   zip .app (submit)                    zip .app (submit)
+                          │                                   │
+                   notarize .app                        notarize .app
+                          │                                   │
+                    staple .app                          staple .app
+                          │                                   │
+                   create output zip                     create DMG
+                          │                                   │
+                   ✓ Ready to ship                    sign + notarize DMG
+                                                              │
+                                                         staple DMG
+                                                              │
+                                                       ✓ Ready to ship
 ```
 
 ## Before you start
@@ -65,11 +75,12 @@ lipo -create \
 
 Once you have a `.app`, cargo-codesign takes over.
 
-## Two modes
+## Three modes
 
 | Mode | Command | What it does |
 |------|---------|-------------|
-| **App mode** | `cargo codesign macos --app "MyApp.app"` | Full chain: sign app → create DMG → sign DMG → notarize → staple |
+| **App mode (zip)** | `cargo codesign macos --app "MyApp.app" --as zip` | Sign app → notarize → staple → output zip |
+| **App mode (dmg)** | `cargo codesign macos --app "MyApp.app" --as dmg` | Sign app → notarize → staple → create DMG → notarize DMG → staple DMG |
 | **Bare binary mode** | `cargo codesign macos` | Discover binaries via `cargo metadata`, sign each, copy to `target/signed/` |
 
-Most GUI apps use **app mode**. CLI tools distributed as standalone binaries use **bare binary mode**.
+Most GUI apps use **app mode**. Use `--as zip` for Homebrew cask distribution, `--as dmg` (default) for website downloads. CLI tools use **bare binary mode**.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,12 @@
 use clap::{Parser, Subcommand};
 
+#[derive(Clone, Default, clap::ValueEnum)]
+enum AppOutputFormat {
+    #[default]
+    Dmg,
+    Zip,
+}
+
 #[derive(Parser)]
 #[command(name = "cargo")]
 #[command(bin_name = "cargo")]
@@ -36,12 +43,15 @@ enum SignCommand {
     Status,
     /// Sign, notarize, and staple macOS artifacts
     Macos {
-        /// Path to .app bundle (triggers full sign+DMG+notarize+staple chain)
+        /// Path to .app bundle (triggers full sign+notarize+staple chain)
         #[arg(long, conflicts_with_all = ["ci_import_cert", "ci_cleanup_cert"])]
         app: Option<std::path::PathBuf>,
         /// Path to existing DMG (codesign + notarize + staple)
         #[arg(long, conflicts_with_all = ["ci_import_cert", "ci_cleanup_cert"])]
         dmg: Option<std::path::PathBuf>,
+        /// Output format when using --app: dmg (default) or zip
+        #[arg(long = "as", value_name = "FORMAT", requires = "app")]
+        output_format: Option<AppOutputFormat>,
         /// Entitlements plist (overrides config)
         #[arg(long)]
         entitlements: Option<std::path::PathBuf>,
@@ -134,6 +144,7 @@ fn main() {
         SignCommand::Macos {
             app,
             dmg,
+            output_format,
             entitlements,
             identity,
             skip_notarize,
@@ -150,6 +161,7 @@ fn main() {
                     args.config.as_deref(),
                     app.as_deref(),
                     dmg.as_deref(),
+                    &output_format.unwrap_or_default(),
                     entitlements.as_deref(),
                     identity.as_deref(),
                     skip_notarize,
@@ -207,6 +219,7 @@ fn cmd_macos(
     config_path: Option<&std::path::Path>,
     app: Option<&std::path::Path>,
     dmg: Option<&std::path::Path>,
+    output_format: &AppOutputFormat,
     entitlements_override: Option<&std::path::Path>,
     identity_override: Option<&str>,
     skip_notarize: bool,
@@ -257,6 +270,7 @@ fn cmd_macos(
             identity,
             entitlements,
             macos_config,
+            output_format,
             skip_notarize,
             skip_staple,
             verbose,
@@ -314,19 +328,47 @@ fn macos_app_mode(
     identity: &str,
     entitlements: Option<&std::path::Path>,
     macos_config: &cargo_codesign::config::MacosConfig,
+    output_format: &AppOutputFormat,
+    skip_notarize: bool,
+    skip_staple: bool,
+    verbose: bool,
+) {
+    match output_format {
+        AppOutputFormat::Zip => macos_app_zip(
+            app_path,
+            identity,
+            entitlements,
+            macos_config,
+            skip_notarize,
+            skip_staple,
+            verbose,
+        ),
+        AppOutputFormat::Dmg => macos_app_dmg(
+            app_path,
+            identity,
+            entitlements,
+            macos_config,
+            skip_notarize,
+            skip_staple,
+            verbose,
+        ),
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn macos_app_zip(
+    app_path: &std::path::Path,
+    identity: &str,
+    entitlements: Option<&std::path::Path>,
+    macos_config: &cargo_codesign::config::MacosConfig,
     skip_notarize: bool,
     skip_staple: bool,
     verbose: bool,
 ) {
     use cargo_codesign::platform::macos;
 
-    let app_name = app_path
-        .file_stem()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_string();
-
-    eprintln!("[1/7] Codesigning .app bundle...");
+    eprintln!("[1/5] Codesigning .app bundle...");
     let opts = macos::CodesignOpts {
         identity,
         entitlements,
@@ -339,21 +381,86 @@ fn macos_app_mode(
     eprintln!("  ✓ App signed");
 
     if !skip_notarize {
-        eprintln!("[2/7] Zipping .app for notarization...");
+        eprintln!("[2/5] Zipping .app for notarization...");
         let zip_path = macos::zip_app(app_path, verbose).unwrap_or_else(|e| {
             eprintln!("✗ Zip creation failed: {e}");
             std::process::exit(1);
         });
         eprintln!("  ✓ Zip created: {}", zip_path.display());
 
-        eprintln!("[3/7] Notarizing .app...");
+        eprintln!("[3/5] Notarizing .app...");
         notarize_artifact(&zip_path, macos_config, verbose);
         eprintln!("  ✓ Notarized");
 
         let _ = std::fs::remove_file(&zip_path);
 
         if !skip_staple {
-            eprintln!("[4/7] Stapling .app...");
+            eprintln!("[4/5] Stapling .app...");
+            macos::staple(app_path, verbose).unwrap_or_else(|e| {
+                eprintln!("✗ App stapling failed: {e}");
+                std::process::exit(1);
+            });
+            eprintln!("  ✓ App stapled");
+        }
+    }
+
+    eprintln!("[5/5] Creating distributable zip...");
+    let zip_path = macos::zip_app(app_path, verbose).unwrap_or_else(|e| {
+        eprintln!("✗ Zip creation failed: {e}");
+        std::process::exit(1);
+    });
+    eprintln!("  ✓ Zip created");
+
+    eprintln!("✓ Done: {}", zip_path.display());
+}
+
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn macos_app_dmg(
+    app_path: &std::path::Path,
+    identity: &str,
+    entitlements: Option<&std::path::Path>,
+    macos_config: &cargo_codesign::config::MacosConfig,
+    skip_notarize: bool,
+    skip_staple: bool,
+    verbose: bool,
+) {
+    use cargo_codesign::platform::macos;
+
+    let app_name = app_path
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    eprintln!("[1/8] Codesigning .app bundle...");
+    let opts = macos::CodesignOpts {
+        identity,
+        entitlements,
+        verbose,
+    };
+    macos::codesign_app(app_path, &opts).unwrap_or_else(|e| {
+        eprintln!("✗ App codesigning failed: {e}");
+        std::process::exit(1);
+    });
+    eprintln!("  ✓ App signed");
+
+    if !skip_notarize {
+        eprintln!("[2/8] Zipping .app for notarization...");
+        let zip_path = macos::zip_app(app_path, verbose).unwrap_or_else(|e| {
+            eprintln!("✗ Zip creation failed: {e}");
+            std::process::exit(1);
+        });
+        eprintln!("  ✓ Zip created: {}", zip_path.display());
+
+        eprintln!("[3/8] Notarizing .app...");
+        notarize_artifact(&zip_path, macos_config, verbose);
+        eprintln!("  ✓ Notarized");
+
+        let _ = std::fs::remove_file(&zip_path);
+
+        if !skip_staple {
+            eprintln!("[4/8] Stapling .app...");
             macos::staple(app_path, verbose).unwrap_or_else(|e| {
                 eprintln!("✗ App stapling failed: {e}");
                 std::process::exit(1);
@@ -363,7 +470,7 @@ fn macos_app_mode(
     }
 
     let dmg_path = app_path.with_extension("dmg");
-    eprintln!("[5/7] Creating DMG...");
+    eprintln!("[5/8] Creating DMG...");
     macos::create_dmg(
         app_path,
         &dmg_path,
@@ -377,7 +484,7 @@ fn macos_app_mode(
     });
     eprintln!("  ✓ DMG created: {}", dmg_path.display());
 
-    eprintln!("[6/7] Codesigning DMG...");
+    eprintln!("[6/8] Codesigning DMG...");
     let dmg_opts = macos::CodesignOpts {
         identity,
         entitlements: None,
@@ -389,13 +496,19 @@ fn macos_app_mode(
     });
     eprintln!("  ✓ DMG signed");
 
-    if !skip_notarize && !skip_staple {
-        eprintln!("[7/7] Stapling DMG...");
-        macos::staple(&dmg_path, verbose).unwrap_or_else(|e| {
-            eprintln!("✗ DMG stapling failed: {e}");
-            std::process::exit(1);
-        });
-        eprintln!("  ✓ DMG stapled");
+    if !skip_notarize {
+        eprintln!("[7/8] Notarizing DMG...");
+        notarize_artifact(&dmg_path, macos_config, verbose);
+        eprintln!("  ✓ Notarized");
+
+        if !skip_staple {
+            eprintln!("[8/8] Stapling DMG...");
+            macos::staple(&dmg_path, verbose).unwrap_or_else(|e| {
+                eprintln!("✗ DMG stapling failed: {e}");
+                std::process::exit(1);
+            });
+            eprintln!("  ✓ DMG stapled");
+        }
     }
 
     eprintln!("✓ Done: {}", dmg_path.display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -735,6 +735,7 @@ fn cmd_macos(
     _config_path: Option<&std::path::Path>,
     _app: Option<&std::path::Path>,
     _dmg: Option<&std::path::Path>,
+    _output_format: &AppOutputFormat,
     _entitlements_override: Option<&std::path::Path>,
     _identity_override: Option<&str>,
     _skip_notarize: bool,


### PR DESCRIPTION
## Summary

- Add `--as zip|dmg` flag to `cargo codesign macos --app`
- `--as zip`: sign → notarize → staple `.app` → output zip (one notarization, ideal for Homebrew cask)
- `--as dmg` (default): sign → notarize → staple `.app` → create DMG → sign → notarize → staple DMG (two notarizations, both artifacts carry tickets)
- Fixes DMG stapling failure from #37 (DMG now gets its own notarization submission)

## Context

When distributing via Homebrew cask, the `.app` is extracted from the container and placed in `/Applications`. Major apps (iTerm2, Signal, VS Code) ship a zip containing the stapled `.app` for this channel — no DMG needed.

The `--as` flag lets users choose the appropriate format per distribution channel without requiring separate tooling.

## Test plan

- [ ] `cargo codesign macos --app Foo.app --as zip` produces zip with stapled `.app`
- [ ] `cargo codesign macos --app Foo.app --as dmg` produces DMG with stapled `.app` + stapled DMG
- [ ] `cargo codesign macos --app Foo.app` (no flag) defaults to DMG
- [ ] `--as` without `--app` is rejected by clap
- [ ] `brew install --cask` from zip artifact passes Gatekeeper on MDM-restricted Mac